### PR TITLE
Fix RA not detecting Scarface (SLUS_211.11)

### DIFF
--- a/decomp/Hackify.bat
+++ b/decomp/Hackify.bat
@@ -26,6 +26,8 @@ lib\xml ed -L -u "androidx.drawerlayout.widget.DrawerLayout/androidx.coordinator
 lib\hexalter 4248\lib\arm64-v8a\libemucore.so 0x838560=0x66,0x00,0x00,0x14 0x83B324=0x62,0x00,0x00,0x14
 :: Patch BIOS type check
 lib\hexalter 4248\lib\arm64-v8a\libemucore.so 0x829248=0x35,0x00,0x80,0x52
+:: Fix RA hash lookup for non-conforming ELF paths (e.g. Scarface SLUS_211.11)
+lib\hexalter 4248\lib\arm64-v8a\libemucore.so 0x80f824=0x05,0x00,0x00,0x14
 
 :: --Patch DEX--
 :: Disable ads


### PR DESCRIPTION

[Scarface.txt](https://github.com/user-attachments/files/29524050/Scarface.txt)
Scarface has a non-standard SYSTEM.CNF where the BOOT2 line ends with a bare semicolon and no version number. The emulator catches this and fixes the path, but the RA hashing function still bails out early due to a zero-length check on the game ID field at 0x80f824. End result is RA never gets a hash to look up, even though the correct hash 320c9c8495acc6defba9d94f0d891e01 is registered on RA for this game.

Patching the cbz to an unconditional branch skips the bad check and lets the hash run normally. Every other game is unaffected since they never hit this code path